### PR TITLE
To my local staging - Don't sleep after the last needed ping

### DIFF
--- a/httping.go
+++ b/httping.go
@@ -205,7 +205,11 @@ func ping(httpVerb string, url *url.URL, count int, hostHeader string, jsonResul
 
 		}
 
-		time.Sleep(1e9)
+		// Don't sleep after the last needed ping, so results can be displayed 1 second faster
+		// (quick mathematics are cheap, 1 second is long)
+		if (count-i) > 1 {
+			time.Sleep(1e9)
+		}
 
 		c := make(chan os.Signal, 1)
 


### PR DESCRIPTION
Let's say user requests 4 pings.

Currently, the program will do as follows,

> 1 - ping
> 2 - sleep 1s
> 3 - ping
> 4 - sleep 1s
> 5 - ping
> 6 - sleep 1s
> 7 - ping
>**8 - sleep 1s**
> 9 - Display stats

The change in this Push Request removes unnecessary step  **8. sleep 1s** , making user wait less. This is the same behavior as in standard ping.

