### PR TITLE
To my local staging - Change - Don't sleep after the last needed ping

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ httping -url requested_url [OPTIONS]
   Requested URL. If no protocol is specified with http:// or https:// the system will use http://
 
 -count *10*
-  Number of requests to send.
+  Number of requests to send (0 means infinite).
   Default: 10
   
 -httpverb *GET*

--- a/httping.go
+++ b/httping.go
@@ -51,7 +51,7 @@ func main() {
 	// Available flags
 	urlPtr := flag.String("url", "", "Requested URL")
 	httpverbPtr := flag.String("httpverb", "GET", "HTTP Verb: Only GET or HEAD supported at the moment")
-	countPtr := flag.Int("count", 10, "Number of requests to send")
+	countPtr := flag.Int("count", 10, "Number of requests to send (0 means infinite)")
 	listenPtr := flag.Int("listen", 0, "Enable listener mode on specified port, e.g. '-r 80'")
 	hostHeaderPtr := flag.String("hostheader", "", "Optional: Host header")
 	jsonResultsPtr := flag.Bool("json", false, "If true, produces output in json format")
@@ -81,14 +81,6 @@ func main() {
 	if len(urlStr) < 1 {
 		flag.Usage()
 		fmt.Printf("\nYou haven't specified a URL to test!\n\n")
-
-		os.Exit(1)
-	}
-
-	// Exit if the number of probes is zero, print usage
-	if *countPtr < 1 {
-		flag.Usage()
-		fmt.Printf("\nNumber of probes has to be greater than 0!\n\n")
 
 		os.Exit(1)
 	}
@@ -153,7 +145,7 @@ func ping(httpVerb string, url *url.URL, count int, hostHeader string, jsonResul
 	}
 
 	// Send requests for url, "count" times
-	for i = 1; count >= i && fBreak == 0; i++ {
+	for i = 1; (count >= i || count < 1) && fBreak == 0; i++ {
 		// Get the request ready - Headers, verb, etc
 		request, err := http.NewRequest(httpVerb, url.String(), nil)
 		request.Host = hostHeader


### PR DESCRIPTION
In some cases, application needs to run infinitely.

I edited code, so that if ping count is set to `0` (or below, e.g., `-1`), httping cycle runs infinitely. This can be extremely useful.

I thought of creating another flag, so I looked through industry practices. MacOS and Linux pings are continuous pings by default, and Windows uses `-t` flag. However, what does `-t` means and why is it not `-c` as in `-continuous` - is unclear. So, modifying `-count` flag behavior seemed like the best option.

You can read more about Continuous Ping [here](https://www.ionos.com/digitalguide/server/tools/continuous-ping/)
