### PR TITLE
To my master branch -  [!AIO] All changes made today in one PR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,25 @@
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+go.work.sum
+
+# Custom
 vendor/

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ httping -url requested_url [OPTIONS]
   Requested URL. If no protocol is specified with http:// or https:// the system will use http://
 
 -count *10*
-  Number of requests to send.
+  Number of requests to send (0 means infinite).
   Default: 10
   
 -httpverb *GET*

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ httping -url requested_url [OPTIONS]
 
 -json
   If specified, outputs the results in json format
+
+-noProxy
+  If specified, ignores system proxy settings
 ```
 
 #### Example

--- a/README.md
+++ b/README.md
@@ -110,6 +110,25 @@ PS C:\temp> .\httping.exe -url https://wormhole.network -count 5 -json
 {"host":"wormhole.network","httpVerb":"GET","hostHeader":"wormhole.network","seq":4,"httpStatus":200,"bytes":10991,"rtt":121.3327}
 {"host":"wormhole.network","httpVerb":"GET","hostHeader":"wormhole.network","seq":5,"httpStatus":200,"bytes":10991,"rtt":71.4523}
 ```
+
+#### Example 3
+
+Continuous monitoring of the connection quality,  
+```
+$ httping.exe -url http://detectportal.firefox.com/success.txt -count 0 -timeout 1000
+
+httping 0.9.1 - A tool to measure RTT on HTTP/S requests
+Help: httping -h
+HTTP GET to detectportal.firefox.com (http://detectportal.firefox.com/success.txt):
+Timeout when connecting to http://detectportal.firefox.com/success.txt
+Timeout when connecting to http://detectportal.firefox.com/success.txt
+connected to http://detectportal.firefox.com/success.txt, seq=3, httpVerb=GET, httpStatus=200, bytes=8, RTT=882.24 ms
+Timeout when connecting to http://detectportal.firefox.com/success.txt
+Timeout when connecting to http://detectportal.firefox.com/success.txt
+Timeout when connecting to http://detectportal.firefox.com/success.txt
+connected to http://detectportal.firefox.com/success.txt, seq=7, httpVerb=GET, httpStatus=200, bytes=8, RTT=928.17 ms
+```
+
 ### Help
 httping help
 

--- a/README.md
+++ b/README.md
@@ -46,9 +46,13 @@ httping -url requested_url [OPTIONS]
   Requested URL. If no protocol is specified with http:// or https:// the system will use http://
 
 -count *10*
-  Number of requests to send (0 means infinite).
+  Number of requests to send [0 means infinite].
   Default: 10
-  
+
+-timeout 2000
+  Timeout in milliseconds
+  Default: 2000 (2 seconds)
+
 -httpverb *GET*
   Verb to use for the HTTP request: GET or HEAD.
   Default: GET

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,8 @@ module github.com/pjperez/httping
 go 1.18
 
 require github.com/montanaflynn/stats v0.6.6
+
+require (
+	github.com/rapid7/go-get-proxied v0.0.0-20240311092404-798791728c56 // indirect
+	golang.org/x/sys v0.22.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,6 @@
 github.com/montanaflynn/stats v0.6.6 h1:Duep6KMIDpY4Yo11iFsvyqJDyfzLF9+sndUKT+v64GQ=
 github.com/montanaflynn/stats v0.6.6/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
+github.com/rapid7/go-get-proxied v0.0.0-20240311092404-798791728c56 h1:NMFnJUxI7m/To0on5bGzxyqZbFQBIK6yfacNj+JP1dg=
+github.com/rapid7/go-get-proxied v0.0.0-20240311092404-798791728c56/go.mod h1:ELOKvSUbHx1oVeecsknc02S0eEAFD+TdV3rTt3BcNzM=
+golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
+golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/httping.go
+++ b/httping.go
@@ -205,7 +205,11 @@ func ping(httpVerb string, url *url.URL, count int, hostHeader string, jsonResul
 
 		}
 
-		time.Sleep(1e9)
+		// Don't sleep after the last needed ping, so results can be displayed 1 second faster
+		// (quick mathematics are cheap, 1 second is long)
+		if (count-i) > 1 {
+			time.Sleep(1e9)
+		}
 
 		c := make(chan os.Signal, 1)
 

--- a/httping.go
+++ b/httping.go
@@ -23,7 +23,7 @@ import (
 	"strconv"
 
 	"github.com/montanaflynn/stats"
-    "github.com/rapid7/go-get-proxied/proxy"
+	"github.com/rapid7/go-get-proxied/proxy"
 )
 
 const httpingVersion = "0.9.1"

--- a/httping.go
+++ b/httping.go
@@ -51,7 +51,7 @@ func main() {
 	// Available flags
 	urlPtr := flag.String("url", "", "Requested URL")
 	httpverbPtr := flag.String("httpverb", "GET", "HTTP Verb: Only GET or HEAD supported at the moment")
-	countPtr := flag.Int("count", 10, "Number of requests to send")
+	countPtr := flag.Int("count", 10, "Number of requests to send (0 means infinite)")
 	listenPtr := flag.Int("listen", 0, "Enable listener mode on specified port, e.g. '-r 80'")
 	hostHeaderPtr := flag.String("hostheader", "", "Optional: Host header")
 	jsonResultsPtr := flag.Bool("json", false, "If true, produces output in json format")
@@ -81,14 +81,6 @@ func main() {
 	if len(urlStr) < 1 {
 		flag.Usage()
 		fmt.Printf("\nYou haven't specified a URL to test!\n\n")
-
-		os.Exit(1)
-	}
-
-	// Exit if the number of probes is zero, print usage
-	if *countPtr < 1 {
-		flag.Usage()
-		fmt.Printf("\nNumber of probes has to be greater than 0!\n\n")
 
 		os.Exit(1)
 	}
@@ -153,7 +145,7 @@ func ping(httpVerb string, url *url.URL, count int, hostHeader string, jsonResul
 	}
 
 	// Send requests for url, "count" times
-	for i = 1; count >= i && fBreak == 0; i++ {
+	for i = 1; (count >= i || count < 1) && fBreak == 0; i++ {
 		// Get the request ready - Headers, verb, etc
 		request, err := http.NewRequest(httpVerb, url.String(), nil)
 		request.Host = hostHeader

--- a/httping.go
+++ b/httping.go
@@ -150,21 +150,29 @@ func ping(httpVerb string, url *url.URL, count int, hostHeader string, jsonResul
 
 	// Change request timeout to 2 seconds
 	timeout := time.Duration(2 * time.Second)
-	
+
 	// set up proxy (if any)
 	transport := &http.Transport{}
 
-	if !noProxy {
-		transport.Proxy = http.ProxyFromEnvironment
-	}
-
-	client := http.Client{
-		Timeout: timeout,
-		Transport: transport,
-	}
-
 	// Send requests for url, "count" times
 	for i = 1; count >= i && fBreak == 0; i++ {
+		// More stateless approach, and as part of it,
+		// each time - init new client - safer in the dynamic environment where proxy changes often
+		// (compute time is cheaper than having to debug)
+		// part 1: set up proxy (if any)
+		transport := &http.Transport{}
+
+		if !noProxy {
+			transport.Proxy = http.ProxyFromEnvironment
+		}
+
+		// part 2: bootstrap client
+		// bootstrap client
+		client := http.Client{
+			Timeout: timeout,
+			Transport: transport,
+		}
+
 		// Get the request ready - Headers, verb, etc
 		request, err := http.NewRequest(httpVerb, url.String(), nil)
 		request.Host = hostHeader

--- a/httping.go
+++ b/httping.go
@@ -53,6 +53,7 @@ func main() {
 	httpverbPtr := flag.String("httpverb", "GET", "HTTP Verb: Only GET or HEAD supported at the moment")
 	countPtr := flag.Int("count", 10, "Number of requests to send")
 	listenPtr := flag.Int("listen", 0, "Enable listener mode on specified port, e.g. '-r 80'")
+	timeoutPtr := flag.Int("timeout", 2000, "Timeout in milliseconds")
 	hostHeaderPtr := flag.String("hostheader", "", "Optional: Host header")
 	jsonResultsPtr := flag.Bool("json", false, "If true, produces output in json format")
 
@@ -89,6 +90,14 @@ func main() {
 	if *countPtr < 1 {
 		flag.Usage()
 		fmt.Printf("\nNumber of probes has to be greater than 0!\n\n")
+
+		os.Exit(1)
+	}
+
+	// Exit if the number of probes is zero, print usage
+	if *timeoutPtr < 0 {
+		flag.Usage()
+		fmt.Printf("\nTimeout has to be greater than 0!!\n\n")
 
 		os.Exit(1)
 	}
@@ -133,10 +142,10 @@ func main() {
 	if jsonResults == false {
 		fmt.Printf("HTTP %s to %s (%s):\n", httpVerb, url.Host, urlStr)
 	}
-	ping(httpVerb, url, *countPtr, hostHeader, jsonResults)
+	ping(httpVerb, url, *countPtr, *timeoutPtr, hostHeader, jsonResults)
 }
 
-func ping(httpVerb string, url *url.URL, count int, hostHeader string, jsonResults bool) {
+func ping(httpVerb string, url *url.URL, count int, max_timeout int, hostHeader string, jsonResults bool) {
 	// This function is responsible to send the requests, count the time and show statistics when finished
 
 	// Initialise needed variables
@@ -146,8 +155,8 @@ func ping(httpVerb string, url *url.URL, count int, hostHeader string, jsonResul
 	var responseTimes []float64
 	fBreak := 0
 
-	// Change request timeout to 2 seconds
-	timeout := time.Duration(2 * time.Second)
+	// Change request timeout to max_timeout seconds
+	timeout := time.Duration(max_timeout) * time.Millisecond
 	client := http.Client{
 		Timeout: timeout,
 	}

--- a/httping.go
+++ b/httping.go
@@ -151,9 +151,6 @@ func ping(httpVerb string, url *url.URL, count int, hostHeader string, jsonResul
 	// Change request timeout to 2 seconds
 	timeout := time.Duration(2 * time.Second)
 
-	// set up proxy (if any)
-	transport := &http.Transport{}
-
 	// Send requests for url, "count" times
 	for i = 1; count >= i && fBreak == 0; i++ {
 		// More stateless approach, and as part of it,

--- a/httping.go
+++ b/httping.go
@@ -55,12 +55,14 @@ func main() {
 	listenPtr := flag.Int("listen", 0, "Enable listener mode on specified port, e.g. '-r 80'")
 	hostHeaderPtr := flag.String("hostheader", "", "Optional: Host header")
 	jsonResultsPtr := flag.Bool("json", false, "If true, produces output in json format")
+	noProxyPtr := flag.Bool("noproxy", false, "If true, ignores system proxy settings")
 
 	flag.Parse()
 
 	urlStr := *urlPtr
 	httpVerb := *httpverbPtr
 	jsonResults := *jsonResultsPtr
+	noProxy := *noProxyPtr
 
 	if jsonResults == false {
 		fmt.Println("\nhttping " + httpingVersion + " - A tool to measure RTT on HTTP/S requests")
@@ -133,10 +135,10 @@ func main() {
 	if jsonResults == false {
 		fmt.Printf("HTTP %s to %s (%s):\n", httpVerb, url.Host, urlStr)
 	}
-	ping(httpVerb, url, *countPtr, hostHeader, jsonResults)
+	ping(httpVerb, url, *countPtr, hostHeader, jsonResults, noProxy)
 }
 
-func ping(httpVerb string, url *url.URL, count int, hostHeader string, jsonResults bool) {
+func ping(httpVerb string, url *url.URL, count int, hostHeader string, jsonResults bool, noProxy bool) {
 	// This function is responsible to send the requests, count the time and show statistics when finished
 
 	// Initialise needed variables
@@ -148,8 +150,17 @@ func ping(httpVerb string, url *url.URL, count int, hostHeader string, jsonResul
 
 	// Change request timeout to 2 seconds
 	timeout := time.Duration(2 * time.Second)
+	
+	// set up proxy (if any)
+	transport := &http.Transport{}
+
+	if !noProxy {
+		transport.Proxy = http.ProxyFromEnvironment
+	}
+
 	client := http.Client{
 		Timeout: timeout,
+		Transport: transport,
 	}
 
 	// Send requests for url, "count" times

--- a/httping.go
+++ b/httping.go
@@ -52,7 +52,7 @@ func main() {
 	// Available flags
 	urlPtr := flag.String("url", "", "Requested URL")
 	httpverbPtr := flag.String("httpverb", "GET", "HTTP Verb: Only GET or HEAD supported at the moment")
-	countPtr := flag.Int("count", 10, "Number of requests to send (0 means infinite)")
+	countPtr := flag.Int("count", 10, "Number of requests to send [0 means infinite]")
 	listenPtr := flag.Int("listen", 0, "Enable listener mode on specified port, e.g. '-r 80'")
 	timeoutPtr := flag.Int("timeout", 2000, "Timeout in milliseconds")
 	hostHeaderPtr := flag.String("hostheader", "", "Optional: Host header")
@@ -85,14 +85,6 @@ func main() {
 	if len(urlStr) < 1 {
 		flag.Usage()
 		fmt.Printf("\nYou haven't specified a URL to test!\n\n")
-
-		os.Exit(1)
-	}
-
-	// Exit if the number of probes is zero, print usage
-	if *countPtr < 1 {
-		flag.Usage()
-		fmt.Printf("\nNumber of probes has to be greater than 0!\n\n")
 
 		os.Exit(1)
 	}
@@ -146,6 +138,9 @@ func main() {
 		fmt.Printf("HTTP %s to %s (%s):\n", httpVerb, url.Host, urlStr)
 	}
 
+	ping(httpVerb, url, *countPtr, *timeoutPtr, hostHeader, jsonResults, noProxy)
+}
+
 func ping(httpVerb string, url *url.URL, count int, max_timeout int, hostHeader string, jsonResults bool, noProxy bool) {
 	// This function is responsible to send the requests, count the time and show statistics when finished
 
@@ -158,9 +153,6 @@ func ping(httpVerb string, url *url.URL, count int, max_timeout int, hostHeader 
 
 	// Change request timeout to max_timeout seconds
 	timeout := time.Duration(max_timeout) * time.Millisecond
-	client := http.Client{
-		Timeout: timeout,
-	}
 	transport := &http.Transport{}
 
 	// Send requests for url, "count" times
@@ -237,7 +229,7 @@ func ping(httpVerb string, url *url.URL, count int, max_timeout int, hostHeader 
 
 		// Don't sleep after the last needed ping, so results can be displayed 1 second faster
 		// (quick mathematics are cheap, 1 second is long)
-		if (count-i) > 1 {
+		if ((count-i) > 1) || (count <= 0) {
 			time.Sleep(1e9)
 		}
 


### PR DESCRIPTION
  Includes #1 , #2 , #3 , and #4 .

1. Continuous (htt)ping support (infinite pings) - see #1 
    * In some cases, application needs to run infinitely. You can read more about Continuous Ping [here](https://www.ionos.com/digitalguide/server/tools/continuous-ping/) .

2. Change - Don't sleep after the last needed ping - see #2  
    * The change in this Push Request removes unnecessary **sleep 1s** , making user wait less. This is the same behavior as in standard ping.

3. **Proxy (proxification) support** - see #3 
    * Adds support for proxies (Google Go does not support it out-of-the-box, so I utilized) [rapid7/go-get-proxied](https://github.com/rapid7/go-get-proxied)
        * [https://github.com/rapid7/go-get-proxied](https://github.com/rapid7/go-get-proxied) was therefore added to dependencies.
    * Add new flag - `noProxy` - to ignore proxies and connect directly

4. Implement timeout flag - see #4 

Additionally, I added a much better `.gitignore`, updated flags in readme, and added an (IRL) example in Readme that made all these changes possible and neccessary.

