### PR TITLE
Staging to Master branch - Changes 06.07.2024

### DIFF
--- a/httping.go
+++ b/httping.go
@@ -151,8 +151,6 @@ func ping(httpVerb string, url *url.URL, count int, max_timeout int, hostHeader 
 	var responseTimes []float64
 	fBreak := 0
 
-	
-
 	// Send requests for url, "count" times
 	for i = 1; (count >= i || count < 1) && fBreak == 0; i++ {
 		// More stateless approach, and as part of it,

--- a/httping.go
+++ b/httping.go
@@ -189,7 +189,7 @@ func ping(httpVerb string, url *url.URL, count int, max_timeout int, hostHeader 
 		responseTime := time.Since(timeStart)
 
 		if err != nil || errRequest != nil {
-			fmt.Println("Timeout when connecting to %s, %s", url, proxyInformation)
+			fmt.Println("Timeout when connecting to", url, "|", proxyInformation)
 
 		} else {
 			// Add all the response times to calculate the average later

--- a/httping.go
+++ b/httping.go
@@ -163,11 +163,11 @@ func ping(httpVerb string, url *url.URL, count int, max_timeout int, hostHeader 
 		transport := &http.Transport{}
 		// Change request timeout to max_timeout seconds
 		timeout := time.Duration(max_timeout) * time.Millisecond
-		proxyInformation := "Not using proxy"
+		proxyInformation := "proxy: None"
 		if !noProxy {
 			p := proxy.NewProvider("").GetProxy(httpVerb, url.String())
 			if p != nil {
-				proxyInformation = fmt.Sprintf("Using proxy: %s", p)
+				proxyInformation = fmt.Sprintf("proxy: %s", p)
 				transport.Proxy = http.ProxyURL(p.URL())
 			}
 		}
@@ -190,7 +190,7 @@ func ping(httpVerb string, url *url.URL, count int, max_timeout int, hostHeader 
 		responseTime := time.Since(timeStart)
 
 		if err != nil || errRequest != nil {
-			fmt.Println("Timeout when connecting to", url, "|", proxyInformation)
+			fmt.Println("Timeout when connecting to", url)
 
 		} else {
 			// Add all the response times to calculate the average later

--- a/httping.go
+++ b/httping.go
@@ -96,6 +96,8 @@ func main() {
 
 		os.Exit(1)
 	}
+	// Change request timeout to requested number of milliseconds
+	timeout := time.Duration(*timeoutPtr) * time.Millisecond
 
 	// Check what protocol has been specified in the URL by checking the first 7 or 8 chars.
 	// If none specified, fall back to HTTP
@@ -138,10 +140,10 @@ func main() {
 		fmt.Printf("HTTP %s to %s (%s):\n", httpVerb, url.Host, urlStr)
 	}
 
-	ping(httpVerb, url, *countPtr, *timeoutPtr, hostHeader, jsonResults, noProxy)
+	ping(httpVerb, url, *countPtr, timeout, hostHeader, jsonResults, noProxy)
 }
 
-func ping(httpVerb string, url *url.URL, count int, max_timeout int, hostHeader string, jsonResults bool, noProxy bool) {
+func ping(httpVerb string, url *url.URL, count int, timeout time.Duration, hostHeader string, jsonResults bool, noProxy bool) {
 	// This function is responsible to send the requests, count the time and show statistics when finished
 
 	// Initialise needed variables
@@ -159,8 +161,6 @@ func ping(httpVerb string, url *url.URL, count int, max_timeout int, hostHeader 
 		// part 1: set up proxy (if any)
 		// Thanks, https://github.com/keyring-so/keyring-desktop/blob/9c6ca18257fee150f922d7559a85e7270373bcdc/app.go#L80
 		transport := &http.Transport{}
-		// Change request timeout to max_timeout seconds
-		timeout := time.Duration(max_timeout) * time.Millisecond
 		proxyInformation := "proxy=None"
 		if !noProxy {
 			p := proxy.NewProvider("").GetProxy(httpVerb, url.String())

--- a/httping.go
+++ b/httping.go
@@ -151,9 +151,7 @@ func ping(httpVerb string, url *url.URL, count int, max_timeout int, hostHeader 
 	var responseTimes []float64
 	fBreak := 0
 
-	// Change request timeout to max_timeout seconds
-	timeout := time.Duration(max_timeout) * time.Millisecond
-	transport := &http.Transport{}
+	
 
 	// Send requests for url, "count" times
 	for i = 1; (count >= i || count < 1) && fBreak == 0; i++ {
@@ -162,6 +160,9 @@ func ping(httpVerb string, url *url.URL, count int, max_timeout int, hostHeader 
 		// (compute time is cheaper than having to debug)
 		// part 1: set up proxy (if any)
 		// Thanks, https://github.com/keyring-so/keyring-desktop/blob/9c6ca18257fee150f922d7559a85e7270373bcdc/app.go#L80
+		transport := &http.Transport{}
+		// Change request timeout to max_timeout seconds
+		timeout := time.Duration(max_timeout) * time.Millisecond
 		proxyInformation := "Not using proxy"
 		if !noProxy {
 			p := proxy.NewProvider("").GetProxy(httpVerb, url.String())

--- a/httping.go
+++ b/httping.go
@@ -162,9 +162,11 @@ func ping(httpVerb string, url *url.URL, count int, max_timeout int, hostHeader 
 		// (compute time is cheaper than having to debug)
 		// part 1: set up proxy (if any)
 		// Thanks, https://github.com/keyring-so/keyring-desktop/blob/9c6ca18257fee150f922d7559a85e7270373bcdc/app.go#L80
+		proxyInformation := "Not using proxy"
 		if !noProxy {
 			p := proxy.NewProvider("").GetProxy(httpVerb, url.String())
 			if p != nil {
+				proxyInformation = fmt.Sprintf("Using proxy: %s", p)
 				transport.Proxy = http.ProxyURL(p.URL())
 			}
 		}
@@ -187,7 +189,7 @@ func ping(httpVerb string, url *url.URL, count int, max_timeout int, hostHeader 
 		responseTime := time.Since(timeStart)
 
 		if err != nil || errRequest != nil {
-			fmt.Println("Timeout when connecting to", url)
+			fmt.Println("Timeout when connecting to %s, %s", url, proxyInformation)
 
 		} else {
 			// Add all the response times to calculate the average later
@@ -216,7 +218,7 @@ func ping(httpVerb string, url *url.URL, count int, max_timeout int, hostHeader 
 				fmt.Println(string(resultsMarshaled))
 
 			} else {
-				fmt.Printf("connected to %s, seq=%d, httpVerb=%s, httpStatus=%d, bytes=%d, RTT=%.2f ms\n", url, i, httpVerb, result.StatusCode, bytes, float32(responseTime)/1e6)
+				fmt.Printf("connected to %s, %s, seq=%d, httpVerb=%s, httpStatus=%d, bytes=%d, RTT=%.2f ms\n", url, proxyInformation, i, httpVerb, result.StatusCode, bytes, float32(responseTime)/1e6)
 			}
 
 			// Count how many probes are successful, i.e. how many get a 200 HTTP StatusCode - If successful also add the result to a slice "responseTimes"

--- a/httping.go
+++ b/httping.go
@@ -163,11 +163,11 @@ func ping(httpVerb string, url *url.URL, count int, max_timeout int, hostHeader 
 		transport := &http.Transport{}
 		// Change request timeout to max_timeout seconds
 		timeout := time.Duration(max_timeout) * time.Millisecond
-		proxyInformation := "proxy: None"
+		proxyInformation := "proxy=None"
 		if !noProxy {
 			p := proxy.NewProvider("").GetProxy(httpVerb, url.String())
 			if p != nil {
-				proxyInformation = fmt.Sprintf("proxy: %s", p)
+				proxyInformation = fmt.Sprintf("proxy=%s", p)
 				transport.Proxy = http.ProxyURL(p.URL())
 			}
 		}
@@ -190,7 +190,7 @@ func ping(httpVerb string, url *url.URL, count int, max_timeout int, hostHeader 
 		responseTime := time.Since(timeStart)
 
 		if err != nil || errRequest != nil {
-			fmt.Println("Timeout when connecting to", url)
+			fmt.Println("Timeout when connecting to", url, "|", proxyInformation)
 
 		} else {
 			// Add all the response times to calculate the average later


### PR DESCRIPTION
Changes in light of the discussion: https://github.com/pjperez/httping/pull/15

* **Feature: print proxy information**

```
Things to note:
* Instead of "Using proxy: XYZ" / "Not using proxy", I made the program say either "proxy=None" or "proxy={{proxy}}". This is to save space, and to match program's vibe (everything's lowercase, `=` in output)
* Proxy information is placed after the URL and before seq. I think it's a good placement, but feel free to play with the string and place it elsewhere.
* When proxy is set, the program says: "proxy=**WinHTTP:NamedProxy|://**{{ipAddress}}:{{port}}" . This is the same behavior as here: https://github.com/keyring-so/keyring-desktop/blob/9c6ca18257fee150f922d7559a85e7270373bcdc/app.go#L80 . *I guess* it's possible to remove the part I highlighted (at worst, through string operations), but I'm not sure if it's needed
* Proxy information is also displayed for ping timeouts. I think it is needed there. If it's not needed there , I can remove it
```


* Bugfix: GetProxy now uses URL parameters (it seemingly doesn't matter, but just in case) - see 
[GetProxy - pass parameters (I guess I forgot to commit this before)](https://github.com/pjperez/httping/pull/15/commits/c070ca0047079bf8a981a28294164f004dd7bf13)

* Bugfix - Strange bug/routing feature (in Go, Windows, Proxy Switching software?) - httping delay increases a lot if transport stays  the same for many proxy changes - now it's reinitialized every time for every ping, and this fixes the problem - https://github.com/pjperez/httping/pull/15/commits/f9594f3a14a6743279b526c158c8e64b527aaff0

* Code improvement - keep just timeout without the "max" for consistency